### PR TITLE
Issue #22 by codebreaker8983: Fixed incorrect variable names.

### DIFF
--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -422,10 +422,10 @@ class ExchangeWebServices {
 	/**
 	 * Function Description
 	 * 
-	 * @param GetUserAvailabilityRequestType $GetUserAvailabilityRequest
+	 * @param GetUserAvailabilityRequestType $request
 	 * @return GetUserAvailabilityResponseType
 	 */
-	public function GetUserAvailability($GetUserAvailabilityRequest) {
+	public function GetUserAvailability($request) {
 		$this->initializeSoapClient();
 		$response = $this->soap->{__FUNCTION__}($request);
 		
@@ -435,10 +435,10 @@ class ExchangeWebServices {
 	/**
 	 * Function Description
 	 * 
-	 * @param GetUserOofSettingsRequest $GetUserOofSettingsRequest
+	 * @param GetUserOofSettingsRequest $request
 	 * @return GetUserOofSettingsResponse
 	 */
-	public function GetUserOofSettings($GetUserOofSettingsRequest) {
+	public function GetUserOofSettings($request) {
 		$this->initializeSoapClient();
 		$response = $this->soap->{__FUNCTION__}($request);
 		
@@ -513,10 +513,10 @@ class ExchangeWebServices {
 	/**
 	 * Function Description
 	 * 
-	 * @param SetUserOofSettingsRequest $SetUserOofSettingsRequest
+	 * @param SetUserOofSettingsRequest $request
 	 * @return SetUserOofSettingsResponse
 	 */
-	public function SetUserOofSettings($SetUserOofSettingsRequest) {
+	public function SetUserOofSettings($request) {
 		$this->initializeSoapClient();
 		$response = $this->soap->{__FUNCTION__}($request);
 		


### PR DESCRIPTION
Fixed request functions that should have been using `$request` but were using a variable with the same name as their request type.

References Issue #22.
