### PR TITLE
composer support (composer.json added)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,13 @@
     "homepage": "https://github.com/jamesiarmes/php-ews/wiki",
     "license": "n.a.",
     "authors": [
-        {"name": "Jame Iarmes", "email": ""}
+        {"name": "Jame Iarmes", "email": ""},
+        {"name": "GitHub Contributors", "homepage": "https://github.com/jamesiarmes/php-ews/graphs/contributors"}
     ],
     "require": {
         "php": ">=5.2.0"
     },
     "autoload": {
-        "classmap": [ "."]
+        "classmap": ["."]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/jamesiarmes/php-ews/wiki",
     "license": "n.a.",
     "authors": [
-        {"name": "Jame Iarmes", "email": ""},
+        {"name": "James Iarmes", "email": "jamesiarmes@gmail.com", "homepage": "http://jamesarmes.com"}
         {"name": "GitHub Contributors", "homepage": "https://github.com/jamesiarmes/php-ews/graphs/contributors"}
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "description": "PHP Exchange Web Services",
     "keywords": ["exchange", "php"],
     "homepage": "https://github.com/jamesiarmes/php-ews/wiki",
-    "license": "n.a.",
+    "license": "proprietary",
     "authors": [
-        {"name": "James Iarmes", "email": "jamesiarmes@gmail.com", "homepage": "http://jamesarmes.com"}
+        {"name": "James Iarmes", "email": "jamesiarmes@gmail.com", "homepage": "http://jamesarmes.com"},
         {"name": "GitHub Contributors", "homepage": "https://github.com/jamesiarmes/php-ews/graphs/contributors"}
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "jamesiarmes/php-ews",
+    "type": "library",
+    "description": "PHP Exchange Web Services",
+    "keywords": ["exchange", "php"],
+    "homepage": "https://github.com/jamesiarmes/php-ews/wiki",
+    "license": "n.a.",
+    "authors": [
+        {"name": "Jame Iarmes", "email": ""}
+    ],
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "autoload": {
+        "classmap": [ "."]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a new dependency manager for PHP. It allows you to specify dependencies on a per-project basis. It takes lots of inspiration from NPM and ruby's bundler.

All you need to support composer is a composer.json file. In order to allow easy installation, the repository needs to be added to [packagist](http://packagist.org/), which is the standard repository for composer. Packagist will fetch all the versions from your github repository tags.

Once it has been added, adding php-ews to a project will be as easy as creating this composer.json file in the project's directory:

    {
        "require": {
            "jamesiarmes/php-ews": "dev-master"
        }
    }

And running this command:

    $ php composer.phar install

Note: Packagist will re-crawl github for new versions all the time. After submitting it once, you don't have to do anything else.

Check out the following information on composer and packagist:

* [getcomposer.org](http://getcomposer.org/)
* [packagist.org](http://packagist.org)
* [composer on GitHub](https://github.com/composer/composer)
* #composer on irc.freenode.net

Cheers!