### PR TITLE
newews() misconfigures the EWS object when username property is set

### DIFF
--- a/EWSAutodiscover.php
+++ b/EWSAutodiscover.php
@@ -384,7 +384,7 @@ class EWSAutodiscover
             }
             return new ExchangeWebServices(
                 $server,
-                $this->email,
+                ($this->username ? $this->username : $this->email),
                 $this->password,
                 $version
             );


### PR DESCRIPTION
The email address associated with one's Exchange mailbox is *not always* equal to said user's username. In such cases, the newews() function failed. Only when this->username is null should we assume we can substitute the email address for the username.