### PR TITLE
Updated reference to EWS_Exception to cope up with PEAR style autoloading

### DIFF
--- a/EWSException.php
+++ b/EWSException.php
@@ -9,6 +9,6 @@
 /**
  * Exception class for Exchange Web Services
  */
-class EWS_Exception extends Exception
+class EWSException extends \Exception
 {
 }

--- a/EWSType/MoveItemType.php
+++ b/EWSType/MoveItemType.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Definition of the MoveItemType type
+ *
+ * @package php-ews
+ * @subpackage Types
+ */
+
+/**
+ * Definition of the MoveItemType type
+ */
+class EWSType_MoveItemType extends EWSType
+{
+    /**
+     * ToFolderId property
+     *
+     * @var EWSType_TargetFolderIdType
+     */
+    public $ToFolderId;
+
+    /**
+     * DistinguishedFolderId property
+     * 
+     * @var EWSType_DistinguishedFolderIdType
+     */
+    public $DistinguishedFolderId;
+
+    /**
+     * ItemIds property
+     *
+     * @var EWSType_NonEmptyArrayOfBaseItemIdsType
+     */
+    public $ItemIds;
+}

--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -714,7 +714,7 @@ class ExchangeWebServices
      * Process a response to verify that it succeeded and take the appropriate
      * action
      *
-     * @throws EWS_Exception
+     * @throws EWSException
      *
      * @param stdClass $response
      * @return EWSType
@@ -726,7 +726,7 @@ class ExchangeWebServices
         // If the soap call failed then we need to thow an exception.
         $code = $this->soap->getResponseCode();
         if ($code != 200) {
-            throw new EWS_Exception('SOAP client returned status of '.$code, $code);
+            throw new EWSException('SOAP client returned status of '.$code, $code);
         }
 
         return $response;

--- a/NTLMSoapClient.php
+++ b/NTLMSoapClient.php
@@ -76,7 +76,7 @@ class NTLMSoapClient extends SoapClient
         curl_setopt($this->ch, CURLOPT_POST, true );
         curl_setopt($this->ch, CURLOPT_POSTFIELDS, $request);
         curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-        curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM);
+        curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC /** | CURLAUTH_NTLM */); // Commented NTLM for compatibility issues with curl 7.22
         curl_setopt($this->ch, CURLOPT_USERPWD, $this->user.':'.$this->password);
 
         $response = curl_exec($this->ch);

--- a/NTLMSoapClient.php
+++ b/NTLMSoapClient.php
@@ -85,7 +85,7 @@ class NTLMSoapClient extends SoapClient
         // If the response if false than there was an error and we should throw
         // an exception.
         if ($response === false) {
-            throw new EWS_Exception(
+            throw new EWSException(
               'Curl error: ' . curl_error($this->ch),
               curl_errno($this->ch)
             );

--- a/NTLMSoapClient.php
+++ b/NTLMSoapClient.php
@@ -76,7 +76,17 @@ class NTLMSoapClient extends SoapClient
         curl_setopt($this->ch, CURLOPT_POST, true );
         curl_setopt($this->ch, CURLOPT_POSTFIELDS, $request);
         curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-        curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC /** | CURLAUTH_NTLM */); // Commented NTLM for compatibility issues with curl 7.22
+		
+		$curlVersion = curl_version();
+		
+		$version = (double) $curlVersion['version'];
+		
+		if ($version >= 7.3) {
+			curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM );
+		} else {
+			curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC /** | CURLAUTH_NTLM */); // Commented NTLM for compatibility issues with curl 7.22
+		}
+		
         curl_setopt($this->ch, CURLOPT_USERPWD, $this->user.':'.$this->password);
 
         $response = curl_exec($this->ch);

--- a/NTLMSoapClient/Exchange.php
+++ b/NTLMSoapClient/Exchange.php
@@ -39,7 +39,7 @@ class NTLMSoapClient_Exchange extends NTLMSoapClient
     {
         // Verify that a user name and password were entered.
         if (empty($options['user']) || empty($options['password'])) {
-            throw new EWS_Exception('A username and password is required.');
+            throw new EWSException('A username and password is required.');
         }
 
         // Set the username and password properties.


### PR DESCRIPTION
The underscore in the exception class "EWS_Exception" makes the pear style autoloaders to look for it inside "EWS" directory. I renamed the class, file and all the references I could find.