### PR TITLE
Typo Fix - EWSYType to EWSType

### DIFF
--- a/EWSType/TraversalType.php
+++ b/EWSType/TraversalType.php
@@ -8,7 +8,7 @@
  *
  * @package php-ews\Enumerations
  */
-class EWSType_TraversalType extends EWSYType
+class EWSType_TraversalType extends EWSType
 {
     /**
      * Consider both direct children as well as all children contained within


### PR DESCRIPTION
This is fixing a typo when extending EWSType for EWSType_TraversalType.
This fix resolves issues we experienced using our in house autoloader.