### PR TITLE
Fixing cURL call to work with PHP 7

### DIFF
--- a/NTLMSoapClient.php
+++ b/NTLMSoapClient.php
@@ -77,6 +77,7 @@ class NTLMSoapClient extends SoapClient
         curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM);
         curl_setopt($this->ch, CURLOPT_USERPWD, $this->user.':'.$this->password);
+        curl_setopt($this->ch, CURLOPT_FORBID_REUSE, true);
 
         $response = curl_exec($this->ch);
 


### PR DESCRIPTION
After upgrading to PHP php-ews stop to work. After adding CURLOPT_FORBID_REUSE in the cURL call, the library work again.