### PR TITLE
Protection against XXE exploits: 

### DIFF
--- a/src/jamesiarmes/PhpEws/Client.php
+++ b/src/jamesiarmes/PhpEws/Client.php
@@ -703,6 +703,7 @@ class Client
      */
     protected function initializeSoapClient()
     {
+        $backup = libxml_disable_entity_loader(true);
         $this->soap = new SoapClient(
             dirname(__FILE__) . '/assets/services.wsdl',
             array(
@@ -713,6 +714,7 @@ class Client
                 'impersonation' => $this->impersonation,
             )
         );
+        libxml_disable_entity_loader($backup);
 
         return $this->soap;
     }


### PR DESCRIPTION
https://www.sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/

For more info.

Basically, it's recommended to call the next method at the beginning of your application, any application.
`libxml_disable_entity_loader(true);`

Since we need the loading of a wsdl file here, we need to temporarily enable the loader again in case it has been disabled. After that, gentleman as we are, we reset the setting to its original state.
