### PR TITLE
Rename String class to StringType as String is a reserved word in PHP7.

### DIFF
--- a/src/jamesiarmes/PhpEws/Type/BodyType.php
+++ b/src/jamesiarmes/PhpEws/Type/BodyType.php
@@ -10,7 +10,7 @@ namespace jamesiarmes\PhpEws\Type;
  *
  * @package php-ews\Type
  */
-class BodyType extends String
+class BodyType extends StringType
 {
     /**
      * Specifies the type of the body.

--- a/src/jamesiarmes/PhpEws/Type/StringType.php
+++ b/src/jamesiarmes/PhpEws/Type/StringType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains \jamesiarmes\PhpEws\Type\String;
+ * Contains \jamesiarmes\PhpEws\Type\StringType;
  */
 
 namespace jamesiarmes\PhpEws\Type;
@@ -12,7 +12,7 @@ use \jamesiarmes\PhpEws\Type;
  *
  * @package php-ews\Type
  */
-abstract class String extends Type
+abstract class StringType extends Type
 {
     /**
      * Value of the element.

--- a/src/jamesiarmes/PhpEws/Type/TransitionTargetType.php
+++ b/src/jamesiarmes/PhpEws/Type/TransitionTargetType.php
@@ -12,7 +12,7 @@ namespace jamesiarmes\PhpEws\Type;
  *
  * @package php-ews\Type
  */
-class TransitionTargetType extends String
+class TransitionTargetType extends StringType
 {
     /**
      * Indicates whether the time zone transition target is a time zone period


### PR DESCRIPTION
As described on [php.net](http://php.net/manual/en/reserved.other-reserved-words.php), 'String' is now a reserved word in PHP7 and, among other things, cannot be used as a class name.

While I'm not sure of the exact naming scheme in PHP-EWS, renaming the /PhpEws/Type/String class to StringType seemed the most logical.