### PR TITLE
Add branch alias for 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "1.0.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "psr-4": {
       "": "src/"
     }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0-dev"
+    }
   }
 }


### PR DESCRIPTION
Instead of requiring `dev-master`, you can require `1.0@dev` to test the current dev version. dev-master is usually not a good idea. 