### PR TITLE
Fix case for index

### DIFF
--- a/src/Autodiscover.php
+++ b/src/Autodiscover.php
@@ -646,7 +646,7 @@ class Autodiscover
                 return false;
             case 'redirectAddr':
                 $this->redirect = array(
-                    'redirectAddr' => $response['Account']['redirectAddr']
+                    'redirectAddr' => $response['Account']['RedirectAddr']
                 );
                 return false;
             case 'settings':


### PR DESCRIPTION
The $response['Account'] array has 'Action' and a 'RedirectUrl' (with a capital 'R') as keys.