### PR TITLE
save discovered info, if any

### DIFF
--- a/src/Autodiscover.php
+++ b/src/Autodiscover.php
@@ -345,7 +345,7 @@ class Autodiscover
     {
         // Discovery not yet attempted.
         if ($this->discovered === null) {
-            $this->discover();
+            $this->discovered = $this->discover();
         }
 
         // Discovery not successful.


### PR DESCRIPTION
This fix prevents discovered from staying null, but instead should be false if it fails in the discover() function.