### PR TITLE
Fix for libxml entity loader disabled

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1600,6 +1600,9 @@ class Client
      */
     protected function initializeSoapClient()
     {
+        // Enable entity loader (required for loading the WSDL)
+        $entityLoaderDisabled = \libxml_disable_entity_loader(false);
+        
         $this->soap = new SoapClient(
             dirname(__FILE__) . '/assets/services.wsdl',
             array(
@@ -1611,6 +1614,9 @@ class Client
                 'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
             )
         );
+        
+        // Reset previous setting
+        \libxml_disable_entity_loader($entityLoaderDisabled);
 
         return $this->soap;
     }


### PR DESCRIPTION
If the libxml entity loader was disabled by default (for security reasons), you got the error:
"SOAP-ERROR: Parsing WSDL: Couldn't load from '[...]/src/assets/services.wsdl' : failed to load external entity"

This fix temporarily enables entity loading and saves hours of debugging and searching. :)