### PR TITLE
Corrected invalid default value

### DIFF
--- a/src/ArrayType/ArrayOfTransitionsType.php
+++ b/src/ArrayType/ArrayOfTransitionsType.php
@@ -31,7 +31,7 @@ class ArrayOfTransitionsType extends ArrayType
      *
      * @var string
      */
-    public $Id = array();
+    public $Id;
 
     /**
      * A time zone transition that occurs on a specified day of the year.


### PR DESCRIPTION
The property 'Id' is of type string, but the default value was an array. This resulted in an array to string conversion error, when using requests with timezone definitions (previously requested with 'GetServerTimeZones').