### PR TITLE
Temporarily disables XXE protection

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1604,6 +1604,7 @@ class Client
      */
     protected function initializeSoapClient()
     {
+        $backup = libxml_disable_entity_loader(false);
         $this->soap = new SoapClient(
             dirname(__FILE__) . '/assets/services.wsdl',
             array(
@@ -1615,6 +1616,7 @@ class Client
                 'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
             )
         );
+        libxml_disable_entity_loader($backup);
 
         return $this->soap;
     }


### PR DESCRIPTION
I'd like to re-open this PR (previously here: https://github.com/jamesiarmes/php-ews/pull/353)

https://www.sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/

For more info.

Basically, it's recommended to call the next method at the beginning of your application, any application.
`libxml_disable_entity_loader(true);`

Since we need the loading of a wsdl file here, we need to temporarily enable the loader again in case it has been disabled. After that, gentleman as we are, we reset the setting to its original state.

I agree that this is a setting to be decided upon on application level, but this is needed for this library to work at all. By reducing the risk to just 1 operation, we pretty much eliminate risk and allow the users of the library to just disable the entity loader by default.