### PR TITLE
restart autodiscover process when RedirectAddr is found

### DIFF
--- a/src/Autodiscover.php
+++ b/src/Autodiscover.php
@@ -261,9 +261,12 @@ class Autodiscover
         );
         $action = 0;
         $bailout = 10;
+        $redirectCount = 0;
+        $maxRedirects = 5;
 
         while (!$result && ($action < count($actions)) && $bailout--) {
-            if (is_array($this->redirect)) {
+            if (is_array($this->redirect) && $redirectCount < $maxRedirects) {
+                $redirectCount++;
                 if ($this->email != $this->redirect['redirectAddr']) {
                     $action = 0;
                     $this->email = $this->redirect['redirectAddr'];


### PR DESCRIPTION
In the hybrid environment, this library was not able to successfully perform autodiscover process. In this case we have to follow the RedirectAddr.

I have followed Microsoft documentation on what to do if RedirectAddr is found.

Here is the link to Microsoft documentation - https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/handling-autodiscover-error-messages#restarting-autodiscover-with-a-new-email-address

> When you get a new email address in an Autodiscover redirect response, first verify that the new email address that was provided in the redirect error response is not the same address that you sent in the request that resulted in the error. If it is, you should not restart Autodiscover and instead consider the URL that generated the response to be invalid.
> 
> If the new email address is different, discard your existing list of potential Autodiscover endpoint URLs and generate a new list based on the new email address.