### PR TITLE
Add ProposedStart and ProposedEnd elements to WellKnownResponseObjectType

### DIFF
--- a/src/Type/WellKnownResponseObjectType.php
+++ b/src/Type/WellKnownResponseObjectType.php
@@ -12,5 +12,26 @@ namespace jamesiarmes\PhpEws\Type;
  */
 abstract class WellKnownResponseObjectType extends ResponseObjectType
 {
+	/**
+     * Represents the proposed end time of a meeting.
+     *
+     * @since Exchange 2013
+     *
+     * @var string
+     *
+     * @todo Make a DateTime object.
+     */
+    public $ProposedEnd;
+	
+	/**
+     * Represents the proposed start time of a meeting.
+     *
+     * @since Exchange 2013
+     *
+     * @var string
+     *
+     * @todo Make a DateTime object.
+     */
+    public $ProposedStart;
 
 }


### PR DESCRIPTION
As per the [Exchange docs](https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/how-to-propose-a-new-meeting-time-by-using-ews-in-exchange), the AcceptItem, DeclineItem and TentativelyAcceptItem response objects can have ProposedStart and ProposedEnd elements to suggest a new time for a meeting. WellKnownResponseObjectType is inhereted by these three response object exclusively.