### PR TITLE
Fixed Parameter in GetStreamingEventsType.php

### DIFF
--- a/src/Request/GetStreamingEventsType.php
+++ b/src/Request/GetStreamingEventsType.php
@@ -31,5 +31,5 @@ class GetStreamingEventsType extends BaseRequestType
      *
      * @var \jamesiarmes\PhpEws\ArrayType\NonEmptyArrayOfSubscriptionIdsType
      */
-    public $SubscriptionId;
+    public $SubscriptionIds;
 }


### PR DESCRIPTION
In the docs: https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/getstreamingevents

The correct paramter is "SubscriptionIds"